### PR TITLE
fix gci docker-build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu-debootstrap:14.04
 
-COPY ./gci .
+COPY ./gci-test gci
 RUN mv gci /bin
 
 CMD gci


### PR DESCRIPTION
it tries to copy a `gci` binary, but it should copy `gci-test` because that's what `gci build` creates
