### PR TITLE
switching away from the code.google.com uuid implementation

### DIFF
--- a/actions/build.go
+++ b/actions/build.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/arschles/gci/config"
 	"github.com/arschles/gci/dockutil"
 	"github.com/arschles/gci/log"
 	"github.com/codegangsta/cli"
+	"github.com/pborman/uuid"
 )
 
 func Build(c *cli.Context) {

--- a/actions/test.go
+++ b/actions/test.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/arschles/gci/config"
 	"github.com/arschles/gci/dockutil"
 	"github.com/arschles/gci/log"
 	"github.com/codegangsta/cli"
+	"github.com/pborman/uuid"
 )
 
 func Test(c *cli.Context) {

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,6 @@
-hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-updated: 2015-12-31T18:16:08.258683868-08:00
+hash: 832b5b4eae0f0826dfaa0be605253399b36b80441f720ff03c15ffd7378b76e9
+updated: 2016-02-15T08:44:52.890378536-08:00
 imports:
-- name: code.google.com/p/go-uuid
-  version: 35bc42037350
-  subpackages:
-  - uuid
 - name: github.com/arschles/assert
   version: 6882f85ccdc7c1822b146d1a6b0c2c48f91b5140
 - name: github.com/aybabtme/rgbterm
@@ -13,14 +9,28 @@ imports:
   version: 0302d3914d2a6ad61404584cdae6e6dbc9c03599
 - name: github.com/fsouza/go-dockerclient
   version: e0d22d30691bcc996eca51f729a4777b8c7dc2a8
+  subpackages:
+  - external/github.com/docker/docker/opts
+  - external/github.com/docker/docker/pkg/archive
+  - external/github.com/docker/docker/pkg/fileutils
+  - external/github.com/docker/docker/pkg/homedir
+  - external/github.com/docker/docker/pkg/stdcopy
+  - external/github.com/hashicorp/go-cleanhttp
+  - external/github.com/docker/docker/pkg/parsers
+  - external/github.com/docker/docker/pkg/ulimit
+  - external/github.com/Sirupsen/logrus
+  - external/github.com/docker/docker/pkg/idtools
+  - external/github.com/docker/docker/pkg/ioutils
+  - external/github.com/docker/docker/pkg/pools
+  - external/github.com/docker/docker/pkg/promise
+  - external/github.com/docker/docker/pkg/system
+  - external/github.com/opencontainers/runc/libcontainer/user
 - name: github.com/labstack/gommon
   version: cc4f2986014fdd1f2e7800b3c082af17cad28db2
   subpackages:
-  - /color
-- name: github.com/mattn/go-colorable
-  version: 3dac7b4f76f6e17fb39b768b89e3783d16e237fe
-- name: github.com/mattn/go-isatty
-  version: 56b76bdf51f7708750eac80fa38b952bb9f32639
+  - color
+- name: github.com/pborman/uuid
+  version: cd53251766d76cf1969596428dc09c7b97956eeb
 - name: gopkg.in/yaml.v2
   version: f7716cbe52baa25d2e9b0d0da546fcf909fc16b4
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,8 +8,7 @@ import:
 - package: github.com/labstack/gommon
   version: cc4f2986014fdd1f2e7800b3c082af17cad28db2
   subpackages:
-  - /color
+  - color
 - package: github.com/arschles/assert
-- package: code.google.com/p/go-uuid/uuid
 - package: github.com/fsouza/go-dockerclient
-- package: code.google.com/p/go-uuid/uuid
+- package: github.com/pborman/uuid

--- a/util/rand.go
+++ b/util/rand.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"time"
 
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 )
 
 func init() {


### PR DESCRIPTION
also switches to use [Glide 0.9.0 Release Candidate 1](https://github.com/Masterminds/glide/releases/tag/0.9.0-rc1)
