### PR TITLE
Add functionality to pull images if they don't exist

### DIFF
--- a/actions/docker_build.go
+++ b/actions/docker_build.go
@@ -17,6 +17,7 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 )
 
+// DockerBuild is the CLI action for 'gci docker-build'
 func DockerBuild(c *cli.Context) {
 	dockerClient := dockutil.ClientOrDie()
 

--- a/actions/docker_push.go
+++ b/actions/docker_push.go
@@ -11,6 +11,7 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 )
 
+// DockerPush is the cli action for 'gci docker-push'
 func DockerPush(c *cli.Context) {
 	dockerClient := dockutil.ClientOrDie()
 	cfg := config.ReadOrDie(c.String(FlagConfigFile))

--- a/util/docker/build.go
+++ b/util/docker/build.go
@@ -19,7 +19,8 @@ func goxOutputTpl(binPath string) string {
 	return fmt.Sprintf("%s_{{.OS}}_{{.Arch}}", binPath)
 }
 
-func imageName(crossCompile bool) string {
+// ImageName returns the image name to use, given whether we're trying to cross-compile or not
+func ImageName(crossCompile bool) string {
 	if crossCompile {
 		return GoxImage
 	}
@@ -36,6 +37,7 @@ func command(crossCompile bool, binaryPath string) []string {
 // Build runs the build of rootDir inside a Docker container, putting binaries into outDir
 func Build(
 	dockerCl *docker.Client,
+	imgName,
 	rootDir,
 	outDir,
 	packageName,
@@ -46,7 +48,6 @@ func Build(
 	errCh chan<- error) {
 
 	projName := filepath.Base(rootDir)
-	imgName := imageName(cfg.Build.CrossCompile)
 	containerName := fmt.Sprintf("gci-build-%s-%s", projName, uuid.New())
 	logsCh <- build.LogFromString("Creating container %s to build %s", containerName, packageName)
 

--- a/util/docker/image.go
+++ b/util/docker/image.go
@@ -1,0 +1,71 @@
+package docker
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	errInvalidImageName = errors.New("invalid image name")
+)
+
+// Image represents a single image name, including all information about its registry, repository and tag
+type Image struct {
+	registry string
+	repo     string
+	name     string
+	tag      string
+}
+
+// ParseImageFromName parses a raw image name string into an Image
+func ParseImageFromName(name string, shortTag bool) (*Image, error) {
+	spl := strings.Split(name, "/")
+	splLast := strings.Split(spl[len(spl)-1], ":")
+	tag := "latest"
+	if len(splLast) > 1 {
+		tag = splLast[1]
+		spl[len(spl)-1] = splLast[0]
+	}
+	if len(spl) == 1 {
+		// dockerhub trusted image
+		return &Image{
+			registry: "",
+			repo:     "",
+			name:     spl[0],
+			tag:      tag,
+		}, nil
+	} else if len(spl) == 2 {
+		// dockerhub image
+		return &Image{
+			registry: "",
+			repo:     spl[0],
+			name:     spl[1],
+			tag:      tag,
+		}, nil
+	} else if len(spl) == 3 {
+		// non-dockerhub image
+		return &Image{
+			registry: spl[0],
+			repo:     spl[1],
+			name:     spl[2],
+			tag:      tag,
+		}, nil
+	}
+	return nil, errInvalidImageName
+}
+
+// FullWithoutTag returns the full image name without its tag
+func (i Image) FullWithoutTag() string {
+	return strings.Split(i.String(), ":")[0]
+}
+
+// String is the fmt.Stringer interface implementation. It returns the full image name and its tag
+func (i Image) String() string {
+	if i.registry != "" {
+		return fmt.Sprintf("%s/%s/%s:%s", i.registry, i.repo, i.name, i.tag)
+	} else if i.repo != "" {
+		return fmt.Sprintf("%s/%s:%s", i.repo, i.name, i.tag)
+	}
+	return fmt.Sprintf("%s:%s", i.name, i.tag)
+}

--- a/util/docker/images.go
+++ b/util/docker/images.go
@@ -1,0 +1,44 @@
+package docker
+
+import (
+	"io"
+	"strings"
+
+	dlib "github.com/fsouza/go-dockerclient"
+)
+
+// GetImages gets images matching img from dockerCl. Returns an empty slice and a non-nil error if there was an error talking to the daemon
+func GetImages(dockerCl *dlib.Client, img *Image) ([]dlib.APIImages, error) {
+	return dockerCl.ListImages(dlib.ListImagesOptions{
+		All:    false,
+		Filter: img.String(),
+	})
+}
+
+// PullImageStatus represents the status of an image pull
+type PullImageStatus interface {
+	String() string
+}
+
+// EnsureImage ensures that image is on the docker daemon pointed to by dockerCl. If it doesn't, then it attempts to pull the image. If the image doesn't exist, calls ifNotExists before proceeding to download the image. If ifNotExists returns an error, immediately returns that error. Otherwise, returns any error pulling the image.
+func EnsureImage(dockerCl *dlib.Client, image string, ifNotExists func() (io.Writer, error)) error {
+	if _, err := dockerCl.InspectImage(image); err != nil {
+		statusOut, err := ifNotExists()
+		if err != nil {
+			return err
+		}
+		spl := strings.Split(image, ":")
+		repo := spl[0]
+		tag := ""
+		if len(spl) > 1 {
+			tag = spl[1]
+		}
+		pullOpts := dlib.PullImageOptions{Repository: repo, Tag: tag, OutputStream: statusOut}
+		authConf := dlib.AuthConfiguration{}
+		if err := dockerCl.PullImage(pullOpts, authConf); err != nil {
+			return err
+		}
+		return nil
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes #61

Still TODO:
- [x] Refactor the docker utility function `Build` to take in an image name
- [x] Stream the image download logs
